### PR TITLE
feat: Update domain name to docs.edenia.com

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,13 +9,13 @@
 // site configuration options.
 
 const siteConfig = {
-  title: "EOSIO + Antelope Documentation",
-  tagline: "Developer Documentation for EOSIO + Antelope Blockchain Networks",
-  url: "https://guide.edenia.com",
+  title: "Edenia Web3 Development",
+  tagline: "Developer Documentation for Edenia Web3 Development",
+  url: "https://docs.edenia.com",
   baseUrl: "/", // Base URL for your project */
-  //cname: "guide.eoscostarica.io",
+  cname: "docs.edenia.com",
   // Used for publishing and more
-  projectName: "guide.edenia.com",
+  projectName: "docs.edenia.com",
   organizationName: "edenia",
   favicon: "img/favicon/favicon.ico",
   //scripts: ['https://buttons.github.io/buttons.js','../../scripts/languageSelector.js'],
@@ -73,7 +73,7 @@ const siteConfig = {
       logo: {
         alt: "EOS Costa Rica Logo",
         src: "/img/byw-horizontal-transparent.png",
-        href: "https://guide.eoscostarica.io/",
+        href: "https://docs.edenia.com/",
       },
       links: [
         {
@@ -149,7 +149,7 @@ const siteConfig = {
           path: "./docs",
           // Sidebars file relative to website dir.
           editUrl:
-            "https://github.com/eoscostarica/guide.eoscostarica.io/tree/master/",
+            "https://github.com/edenia/docs.edenia.com/tree/master/",
           sidebarPath: require.resolve("./sidebars.js"),
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-docs.edenia.com 
+docs.edenia.com

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+docs.edenia.com 


### PR DESCRIPTION
## Summary
This PR updates the domain name for the Docusaurus site from guide.edenia.com to docs.edenia.com.

## Changes Made
- 🌐 **Updated main URL** in docusaurus.config.js to https://docs.edenia.com
- 📝 **Updated project name** to docs.edenia.com
- ⚙️ **Enabled CNAME configuration** in Docusaurus config
- 📄 **Added CNAME file** in static directory for GitHub Pages custom domain support
- 🔗 **Updated footer logo href** to use new domain
- 📝 **Updated GitHub repository URL** in edit links to point to edenia/docs.edenia.com
- 🏷️ **Updated site title and tagline** to reflect Edenia branding

## Deployment Notes
After merging this PR, the following manual steps will be needed:
1. Configure GitHub Pages custom domain in repository settings
2. Set up DNS records to point docs.edenia.com to GitHub Pages
3. Verify SSL certificate is generated for the new domain

## Testing
- ✅ Configuration syntax is valid
- ✅ CNAME file is properly formatted
- ✅ All domain references have been updated consistently