### PR TITLE
sitemap generation 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -196,8 +196,34 @@ const siteConfig = {
         sitemap: {
           changefreq: 'weekly',
           priority: 0.5,
-          ignorePatterns: [],
+          ignorePatterns: ['/search/**', '**/tags/**'],
           filename: 'sitemap.xml',
+          createSitemapItems: async (params) => {
+            const {defaultCreateSitemapItems, ...rest} = params;
+            const items = await defaultCreateSitemapItems(rest);
+            
+            // Add hreflang attributes for multilingual SEO
+            return items.map((item) => {
+              const isDefaultLocale = !item.url.includes('/es/');
+              const alternateUrl = isDefaultLocale 
+                ? `https://docs.edenia.com/es${item.url.replace('https://docs.edenia.com', '')}`
+                : item.url.replace('/es/', '/');
+                
+              return {
+                ...item,
+                links: [
+                  {
+                    lang: isDefaultLocale ? 'en' : 'es',
+                    url: item.url,
+                  },
+                  {
+                    lang: isDefaultLocale ? 'es' : 'en', 
+                    url: alternateUrl,
+                  },
+                ],
+              };
+            });
+          },
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "start:es": "docusaurus start --locale es",
     "build:en": "docusaurus build --locale en",
     "build:es": "docusaurus build --locale es",
-    "write-translations": "docusaurus write-translations"
+    "write-translations": "docusaurus write-translations",
+    "postbuild": "node scripts/generate-sitemap-index.js",
+    "sitemap:generate": "node scripts/generate-sitemap-index.js"
   },
   "dependencies": {
     "@algolia/client-search": "^5.12.0",

--- a/scripts/generate-sitemap-index.js
+++ b/scripts/generate-sitemap-index.js
@@ -1,0 +1,62 @@
+
+/**
+ * Script to generate a sitemap index file that references both English and Spanish sitemaps
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SITE_URL = 'https://docs.edenia.com';
+const BUILD_DIR = path.join(__dirname, '../build');
+
+function generateSitemapIndex() {
+  const sitemapIndexContent = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>${SITE_URL}/sitemap.xml</loc>
+    <lastmod>${new Date().toISOString()}</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>${SITE_URL}/es/sitemap.xml</loc>
+    <lastmod>${new Date().toISOString()}</lastmod>
+  </sitemap>
+</sitemapindex>`;
+
+  const sitemapIndexPath = path.join(BUILD_DIR, 'sitemap-index.xml');
+  
+  try {
+    fs.writeFileSync(sitemapIndexPath, sitemapIndexContent, 'utf8');
+    console.log('✅ Sitemap index generated successfully at:', sitemapIndexPath);
+    console.log('📄 Submit this URL to Google Search Console:', `${SITE_URL}/sitemap-index.xml`);
+  } catch (error) {
+    console.error('❌ Error generating sitemap index:', error);
+    process.exit(1);
+  }
+}
+
+// Check if build directory exists
+if (!fs.existsSync(BUILD_DIR)) {
+  console.error('❌ Build directory not found. Please run "npm run build" first.');
+  process.exit(1);
+}
+
+// Check if individual sitemaps exist
+const enSitemap = path.join(BUILD_DIR, 'sitemap.xml');
+const esSitemap = path.join(BUILD_DIR, 'es', 'sitemap.xml');
+
+if (!fs.existsSync(enSitemap)) {
+  console.error('❌ English sitemap not found at:', enSitemap);
+  process.exit(1);
+}
+
+if (!fs.existsSync(esSitemap)) {
+  console.error('❌ Spanish sitemap not found at:', esSitemap);
+  process.exit(1);
+}
+
+console.log('🔍 Found sitemaps:');
+console.log('  - English:', enSitemap);
+console.log('  - Spanish:', esSitemap);
+console.log('');
+
+generateSitemapIndex();


### PR DESCRIPTION
Add sitemap generation script and update configuration for Google sitemaps submission

### What does this PR do?
This PR adds a custom sitemap generation script to improve SEO and search engine indexing for the documentation site. 

- resolves #37 

### Steps to test
1.Run npm run build to generate the static site
1. Verify that sitemap-index.xml is generated in the build directory

